### PR TITLE
Add ability to escape identifiers to prevent accidental nesting

### DIFF
--- a/packages/redux-dynostore-core/README.md
+++ b/packages/redux-dynostore-core/README.md
@@ -22,8 +22,8 @@ const store = createStore(reducer, dynostore(
 
 Dynamic enhancers are used to make dynamic features available to the store. The following dynamic enhancers are provided:
 
-1. Reducers - dynamically attach reducers
-2. [Sagas](/packages/redux-dynostore-redux-saga) - dynamically run sagas
+1.  Reducers - dynamically attach reducers
+2.  [Sagas](/packages/redux-dynostore-redux-saga) - dynamically run sagas
 
 ### `dynamicReducers`
 
@@ -47,7 +47,7 @@ Multiple reducers can be attached as well:
 store.attachReducers({ dynamicReducer1, dynamicReducer2 })
 ```
 
-Reducers can also be added to nested locations in the store.  The following formats are supported:
+Reducers can also be added to nested locations in the store. The following formats are supported:
 
 ```javascript
 store.attachReducers({ 'some.path.to': dynamicReducer })
@@ -77,7 +77,7 @@ Dynamic enhancers can be created for many use cases by implementing the followin
 const enhancer = createHandlers => (store, reducer, preloadedState) => ({ ...handlers })
 ```
 
-`handlers` is an object with all the functions you want your enhancer to add to the store.  You should only ever append your handlers to the object and not remove any added by other dynamic handlers.
+`handlers` is an object with all the functions you want your enhancer to add to the store. You should only ever append your handlers to the object and not remove any added by other dynamic handlers.
 
 ## Utilities
 
@@ -98,7 +98,43 @@ An enhancer compatible with [`react-redux-dynostore`](/package/react-redux-dynos
 
 ```javascript
 import dynamic from '@redux-dynostore/react-redux'
-import { dispatchAction } from '-redux-dynostore'
+import { dispatchAction } from '@redux-dynostore/core'
 
 export default dynamic('identifier', dispatchAction({ type: 'MY_ACTION' }))(MyComponent)
+```
+
+### `escapeIdentifier`
+
+Escapes the given identifier string so that it does not accidentally trigger additional levels of nesting:
+
+```javascript
+import dynamic from '@redux-dynostore/react-redux'
+import { escapeIdentifier } from '@redux-dynostore/core'
+
+export default dynamic(escapeIdentifier('escaped/identifier'))(MyComponent)
+```
+
+### `escapeIdentifiers`
+
+Escapes the keys of the given object so that it does not accidentally trigger additional levels of nesting:
+
+```javascript
+import { escapeIdentifiers } from '@redux-dynostore/core'
+
+store.attachReducers(escapeIdentifiers({
+  'escaped/identifier': {
+    'escaped/nested/identifier': dynamicReducer
+  }
+})
+```
+
+### `unescapeIdentifier`
+
+Reverses the escaping performed by `escapeIdentifier` and `escapeIdentifiers`:
+
+```javascript
+import { escapeIdentifier, unescapeIdentifier } from '@redux-dynostore/core'
+
+const escaped = escapeIdentifier('escaped/identifier')
+const unexcaped = unescapeIdentifier(escaped)
 ```

--- a/packages/redux-dynostore-core/src/createDynamicReducer.js
+++ b/packages/redux-dynostore-core/src/createDynamicReducer.js
@@ -13,18 +13,17 @@ import filteredReducer from './filteredReducer'
 const expandReducers = reducers => {
   const expandedReducers = { children: {} }
 
-  for (let key in reducers) {
-    let path = key.split('.')
+  for (let flattenedReducer of reducers) {
     let currentNode = expandedReducers
 
-    for (let element of path) {
+    for (let element of flattenedReducer.path) {
       if (!currentNode.children[element]) {
         currentNode.children[element] = { children: {} }
       }
 
       currentNode = currentNode.children[element]
     }
-    currentNode.reducer = reducers[key]
+    currentNode.reducer = flattenedReducer.reducer
   }
 
   return expandedReducers

--- a/packages/redux-dynostore-core/src/dynamicReducers.js
+++ b/packages/redux-dynostore-core/src/dynamicReducers.js
@@ -12,19 +12,16 @@ import createDynamicReducer from './createDynamicReducer'
 import flattenReducers from './flattenReducers'
 
 const dynamicReducersEnhancer = () => createHandlers => (store, reducer, ...rest) => {
-  let dynamicReducers = {}
+  let dynamicReducers = []
 
   const createReducer = () => {
-    const reducers = [
-      filteredReducer(reducer),
-      filteredReducer(createDynamicReducer(dynamicReducers))
-    ]
+    const reducers = [filteredReducer(reducer), filteredReducer(createDynamicReducer(dynamicReducers))]
 
     return concatenateReducers(reducers)
   }
 
   const attachReducers = reducers => {
-    dynamicReducers = { ...dynamicReducers, ...flattenReducers(reducers) }
+    dynamicReducers = [...dynamicReducers, ...flattenReducers(reducers)]
     store.replaceReducer(createReducer())
   }
 

--- a/packages/redux-dynostore-core/src/dynamicReducers.js
+++ b/packages/redux-dynostore-core/src/dynamicReducers.js
@@ -16,12 +16,13 @@ const dynamicReducersEnhancer = () => createHandlers => (store, reducer, ...rest
 
   const createReducer = () => {
     const reducers = [filteredReducer(reducer), filteredReducer(createDynamicReducer(dynamicReducers))]
-
     return concatenateReducers(reducers)
   }
 
   const attachReducers = reducers => {
-    dynamicReducers = [...dynamicReducers, ...flattenReducers(reducers)]
+    const newReducers = flattenReducers(reducers)
+    const newKeys = newReducers.map(r => r.key)
+    dynamicReducers = dynamicReducers.filter(r => !newKeys.includes(r.key)).concat(newReducers)
     store.replaceReducer(createReducer())
   }
 

--- a/packages/redux-dynostore-core/src/escapeIdentifier.js
+++ b/packages/redux-dynostore-core/src/escapeIdentifier.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import isPlainObject from 'lodash.isplainobject'
+
+const DOT_TOKEN = '%%DOT_TOKEN%%'
+const FORWARD_SLASH_TOKEN = '%%FORWARD_SLASH_TOKEN%%'
+
+export const escapeIdentifier = identifier => {
+  return identifier.replace(/\./g, DOT_TOKEN).replace(/\//g, FORWARD_SLASH_TOKEN)
+}
+
+export const escapeIdentifiers = object => {
+  if (!isPlainObject(object)) {
+    return object
+  }
+
+  return Object.keys(object).reduce(
+    (current, key) => ({ ...current, [escapeIdentifier(key)]: escapeIdentifiers(object[key]) }),
+    {}
+  )
+}
+
+export const unescapeIdentifier = identifier => {
+  return identifier.replace(new RegExp(DOT_TOKEN, 'g'), '.').replace(new RegExp(FORWARD_SLASH_TOKEN, 'g'), '/')
+}

--- a/packages/redux-dynostore-core/src/flattenReducers.js
+++ b/packages/redux-dynostore-core/src/flattenReducers.js
@@ -10,7 +10,7 @@ import { unescapeIdentifier, splitIdentifier } from './escapeIdentifier'
 
 const flattenReducers = (reducer, path = []) => {
   if (typeof reducer === 'function') {
-    return { path: path.map(p => unescapeIdentifier(p)), reducer }
+    return { key: path.join('/'), path: path.map(p => unescapeIdentifier(p)), reducer }
   }
 
   return Object.keys(reducer).reduce(

--- a/packages/redux-dynostore-core/src/flattenReducers.js
+++ b/packages/redux-dynostore-core/src/flattenReducers.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { unescapeIdentifier } from './escapeIdentifier'
+import { unescapeIdentifier, splitIdentifier } from './escapeIdentifier'
 
 const flattenReducers = (reducer, path = []) => {
   if (typeof reducer === 'function') {
@@ -14,7 +14,7 @@ const flattenReducers = (reducer, path = []) => {
   }
 
   return Object.keys(reducer).reduce(
-    (current, key) => [...current, ...flattenReducers(reducer[key], [...path, ...key.split(/[./]/g)])],
+    (current, key) => [...current, ...flattenReducers(reducer[key], [...path, ...splitIdentifier(key)])],
     []
   )
 }

--- a/packages/redux-dynostore-core/src/flattenReducers.js
+++ b/packages/redux-dynostore-core/src/flattenReducers.js
@@ -6,17 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const flattenReducers = (reducers, parentKey) => {
-  if (typeof reducers === 'function') {
-    return { [parentKey.replace(/\//g, '.')]: reducers }
+import { unescapeIdentifier } from './escapeIdentifier'
+
+const flattenReducers = (reducer, path = []) => {
+  if (typeof reducer === 'function') {
+    return { path: path.map(p => unescapeIdentifier(p)), reducer }
   }
 
-  return Object.keys(reducers).reduce(
-    (reducerMap, key) => ({
-      ...reducerMap,
-      ...flattenReducers(reducers[key], parentKey ? `${parentKey}.${key}` : key)
-    }),
-    {}
+  return Object.keys(reducer).reduce(
+    (current, key) => [...current, ...flattenReducers(reducer[key], [...path, ...key.split(/[./]/g)])],
+    []
   )
 }
 

--- a/packages/redux-dynostore-core/src/index.js
+++ b/packages/redux-dynostore-core/src/index.js
@@ -12,4 +12,6 @@ export { default as dynamicReducers } from './dynamicReducers'
 export { default as attachReducer } from './attachReducer'
 export { default as dispatchAction } from './dispatchAction'
 
+export { escapeIdentifier, escapeIdentifiers, unescapeIdentifier } from './escapeIdentifier'
+
 export { default as createDynamicTarget } from './createDynamicTarget'

--- a/packages/redux-dynostore-core/test/createDynamicReducer.test.js
+++ b/packages/redux-dynostore-core/test/createDynamicReducer.test.js
@@ -13,15 +13,36 @@ describe('createDynamicReducer Tests', () => {
     const dummyReducer = (state = { value: 0 }, action) =>
       action.type === 'INC' ? { ...state, value: state.value + 1 } : state
 
-    const inputStructure = {
-      foo: dummyReducer,
-      'foo.bar': dummyReducer,
-      'foo.bar.baz': dummyReducer,
-      'foo.bar.qux': dummyReducer,
-      'foo.baz': dummyReducer,
-      bar: dummyReducer,
-      'bar.baz': dummyReducer
-    }
+    const inputStructure = [
+      {
+        path: ['foo'],
+        reducer: dummyReducer
+      },
+      {
+        path: ['foo', 'bar'],
+        reducer: dummyReducer
+      },
+      {
+        path: ['foo', 'bar', 'baz'],
+        reducer: dummyReducer
+      },
+      {
+        path: ['foo', 'bar', 'qux'],
+        reducer: dummyReducer
+      },
+      {
+        path: ['foo', 'baz'],
+        reducer: dummyReducer
+      },
+      {
+        path: ['bar'],
+        reducer: dummyReducer
+      },
+      {
+        path: ['bar', 'baz'],
+        reducer: dummyReducer
+      }
+    ]
 
     const reducer = createDynamicReducer(inputStructure)
 

--- a/packages/redux-dynostore-core/test/dynamicReducers.test.js
+++ b/packages/redux-dynostore-core/test/dynamicReducers.test.js
@@ -29,12 +29,11 @@ describe('dynamicReducers tests', () => {
     const createHandlers = jest.fn()
     const store = { replaceReducer: jest.fn() }
     const reducer = (state = {}) => state
-    const otherHandlers = { other: jest.fn() }
 
     const testReducer1 = (state = 'value1') => state
     const testReducer2 = (state = 'value2') => state
 
-    createHandlers.mockReturnValue(otherHandlers)
+    createHandlers.mockReturnValue({})
 
     const handlers = dynamicReducers()(createHandlers)(store, reducer)
 
@@ -45,6 +44,32 @@ describe('dynamicReducers tests', () => {
     expect(store.replaceReducer.mock.calls[0][0]()).toEqual({
       testReducer1: 'value1',
       testReducer2: 'value2'
+    })
+  })
+
+  test('should override attached reducers with the same key', () => {
+    const createHandlers = jest.fn()
+    const store = { replaceReducer: jest.fn() }
+    const reducer = (state = {}) => state
+
+    const testReducer1 = (state = 'value1') => state
+    const testReducer2 = (state = 'value2') => state
+
+    createHandlers.mockReturnValue({})
+
+    const handlers = dynamicReducers()(createHandlers)(store, reducer)
+
+    handlers.attachReducers({ testReducer: testReducer1 })
+    handlers.attachReducers({ testReducer: testReducer2 })
+
+    expect(store.replaceReducer).toHaveBeenCalledTimes(2)
+
+    expect(store.replaceReducer.mock.calls[0][0]()).toEqual({
+      testReducer: 'value1'
+    })
+
+    expect(store.replaceReducer.mock.calls[1][0]()).toEqual({
+      testReducer: 'value2'
     })
   })
 })

--- a/packages/redux-dynostore-core/test/escapeIdentifier.test.js
+++ b/packages/redux-dynostore-core/test/escapeIdentifier.test.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2018, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { escapeIdentifier, escapeIdentifiers, unescapeIdentifier } from 'src/escapeIdentifier'
+
+describe('escapeIdentifier tests', () => {
+  test('should escape identifier', () => {
+    expect(escapeIdentifier('test')).toBe('test')
+    expect(escapeIdentifier('dot.test')).toBe('dot%%DOT_TOKEN%%test')
+    expect(escapeIdentifier('slash/test')).toBe('slash%%FORWARD_SLASH_TOKEN%%test')
+    expect(escapeIdentifier('multiple.dot.test')).toBe('multiple%%DOT_TOKEN%%dot%%DOT_TOKEN%%test')
+    expect(escapeIdentifier('multiple/slash/test')).toBe(
+      'multiple%%FORWARD_SLASH_TOKEN%%slash%%FORWARD_SLASH_TOKEN%%test'
+    )
+    expect(escapeIdentifier('multiple/mixed.delimeter/test')).toBe(
+      'multiple%%FORWARD_SLASH_TOKEN%%mixed%%DOT_TOKEN%%delimeter%%FORWARD_SLASH_TOKEN%%test'
+    )
+  })
+
+  test('should escape identifiers in object structure', () => {
+    const inputStructure = {
+      ['top.level']: jest.fn(),
+      nested: {
+        ['nested/level']: jest.fn()
+      },
+      multiple: {
+        nested: {
+          ['mutliple.nested/level']: jest.fn()
+        },
+        ['mid/level']: {
+          test: jest.fn()
+        }
+      }
+    }
+
+    expect(escapeIdentifiers(inputStructure)).toEqual({
+      ['top%%DOT_TOKEN%%level']: inputStructure['top.level'],
+      nested: {
+        ['nested%%FORWARD_SLASH_TOKEN%%level']: inputStructure.nested['nested/level']
+      },
+      multiple: {
+        nested: {
+          ['mutliple%%DOT_TOKEN%%nested%%FORWARD_SLASH_TOKEN%%level']:
+            inputStructure.multiple.nested['mutliple.nested/level']
+        },
+        ['mid%%FORWARD_SLASH_TOKEN%%level']: {
+          test: inputStructure.multiple['mid/level'].test
+        }
+      }
+    })
+  })
+
+  test('should unescape identifier', () => {
+    expect(unescapeIdentifier('test')).toBe('test')
+    expect(unescapeIdentifier('dot%%DOT_TOKEN%%test')).toBe('dot.test')
+    expect(unescapeIdentifier('slash%%FORWARD_SLASH_TOKEN%%test')).toBe('slash/test')
+    expect(unescapeIdentifier('multiple%%DOT_TOKEN%%dot%%DOT_TOKEN%%test')).toBe('multiple.dot.test')
+    expect(unescapeIdentifier('multiple%%FORWARD_SLASH_TOKEN%%slash%%FORWARD_SLASH_TOKEN%%test')).toBe(
+      'multiple/slash/test'
+    )
+    expect(
+      unescapeIdentifier('multiple%%FORWARD_SLASH_TOKEN%%mixed%%DOT_TOKEN%%delimeter%%FORWARD_SLASH_TOKEN%%test')
+    ).toBe('multiple/mixed.delimeter/test')
+  })
+})

--- a/packages/redux-dynostore-core/test/escapeIdentifier.test.js
+++ b/packages/redux-dynostore-core/test/escapeIdentifier.test.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { escapeIdentifier, escapeIdentifiers, unescapeIdentifier } from 'src/escapeIdentifier'
+import { escapeIdentifier, escapeIdentifiers, unescapeIdentifier, splitIdentifier } from 'src/escapeIdentifier'
 
 describe('escapeIdentifier tests', () => {
   test('should escape identifier', () => {
@@ -66,5 +66,14 @@ describe('escapeIdentifier tests', () => {
     expect(
       unescapeIdentifier('multiple%%FORWARD_SLASH_TOKEN%%mixed%%DOT_TOKEN%%delimeter%%FORWARD_SLASH_TOKEN%%test')
     ).toBe('multiple/mixed.delimeter/test')
+  })
+
+  test('should split identifier', () => {
+    expect(splitIdentifier('test')).toEqual(['test'])
+    expect(splitIdentifier('dot.test')).toEqual(['dot', 'test'])
+    expect(splitIdentifier('slash/test')).toEqual(['slash', 'test'])
+    expect(splitIdentifier('multiple.dot.test')).toEqual(['multiple', 'dot', 'test'])
+    expect(splitIdentifier('multiple/slash/test')).toEqual(['multiple', 'slash', 'test'])
+    expect(splitIdentifier('multiple/mixed.delimeter/test')).toEqual(['multiple', 'mixed', 'delimeter', 'test'])
   })
 })

--- a/packages/redux-dynostore-core/test/flattenReducers.test.js
+++ b/packages/redux-dynostore-core/test/flattenReducers.test.js
@@ -25,15 +25,19 @@ describe('flattenReducers tests', () => {
 
     const flattenedStructure = flattenReducers(inputStructure)
 
-    expect(flattenedStructure['test']).toBe(inputStructure.test)
-    expect(flattenedStructure['nested.test']).toBe(inputStructure.nested.test)
-    expect(flattenedStructure['multiple.test']).toBe(inputStructure.multiple.test)
-    expect(flattenedStructure['multiple.nested.test']).toBe(inputStructure.multiple.nested.test)
+    expect(flattenedStructure[0].path).toEqual(['test'])
+    expect(flattenedStructure[0].reducer).toBe(inputStructure.test)
+    expect(flattenedStructure[1].path).toEqual(['nested', 'test'])
+    expect(flattenedStructure[1].reducer).toBe(inputStructure.nested.test)
+    expect(flattenedStructure[2].path).toEqual(['multiple', 'test'])
+    expect(flattenedStructure[2].reducer).toBe(inputStructure.multiple.test)
+    expect(flattenedStructure[3].path).toEqual(['multiple', 'nested', 'test'])
+    expect(flattenedStructure[3].reducer).toBe(inputStructure.multiple.nested.test)
   })
 
   test('should normalize delimeters', () => {
     const inputStructure = {
-      'test': jest.fn(),
+      test: jest.fn(),
       'dot.test': jest.fn(),
       'slash/test': jest.fn(),
       'multiple.dot.test': jest.fn(),
@@ -43,11 +47,17 @@ describe('flattenReducers tests', () => {
 
     const flattenedStructure = flattenReducers(inputStructure)
 
-    expect(flattenedStructure['test']).toBe(inputStructure['test'])
-    expect(flattenedStructure['dot.test']).toBe(inputStructure['dot.test'])
-    expect(flattenedStructure['slash.test']).toBe(inputStructure['slash/test'])
-    expect(flattenedStructure['multiple.dot.test']).toBe(inputStructure['multiple.dot.test'])
-    expect(flattenedStructure['multiple.slash.test']).toBe(inputStructure['multiple/slash/test'])
-    expect(flattenedStructure['multiple.mixed.delimeter.test']).toBe(inputStructure['multiple/mixed.delimeter/test'])
+    expect(flattenedStructure[0].path).toEqual(['test'])
+    expect(flattenedStructure[0].reducer).toBe(inputStructure['test'])
+    expect(flattenedStructure[1].path).toEqual(['dot', 'test'])
+    expect(flattenedStructure[1].reducer).toBe(inputStructure['dot.test'])
+    expect(flattenedStructure[2].path).toEqual(['slash', 'test'])
+    expect(flattenedStructure[2].reducer).toBe(inputStructure['slash/test'])
+    expect(flattenedStructure[3].path).toEqual(['multiple', 'dot', 'test'])
+    expect(flattenedStructure[3].reducer).toBe(inputStructure['multiple.dot.test'])
+    expect(flattenedStructure[4].path).toEqual(['multiple', 'slash', 'test'])
+    expect(flattenedStructure[4].reducer).toBe(inputStructure['multiple/slash/test'])
+    expect(flattenedStructure[5].path).toEqual(['multiple', 'mixed', 'delimeter', 'test'])
+    expect(flattenedStructure[5].reducer).toBe(inputStructure['multiple/mixed.delimeter/test'])
   })
 })

--- a/packages/redux-dynostore-core/test/integration.test.js
+++ b/packages/redux-dynostore-core/test/integration.test.js
@@ -7,7 +7,7 @@
  */
 
 import { createStore, combineReducers } from 'redux'
-import dynostore, { dynamicReducers, createDynamicTarget, attachReducer, dispatchAction } from 'src'
+import dynostore, { dynamicReducers, createDynamicTarget, attachReducer, dispatchAction, escapeIdentifier } from 'src'
 
 describe('integration tests', () => {
   const makeTestReducer = id => (state = `${id} - initialValue`, { type, newValue }) => {
@@ -61,6 +61,30 @@ describe('integration tests', () => {
 
     expect(target1).not.toHaveBeenCalled()
     expect(target2).not.toHaveBeenCalled()
+  })
+
+  test('should attach reduce with escaped identifer', () => {
+    const reducer = combineReducers({
+      static1: makeTestReducer('static1'),
+      static2: makeTestReducer('static2')
+    })
+
+    const store = createStore(reducer, dynostore(dynamicReducers()))
+
+    const target = mockTarget(
+      [attachReducer(makeTestReducer('dynamic'))],
+      escapeIdentifier('dynamic/reducer'),
+      store,
+      jest.fn()
+    )
+
+    expect(store.getState()).toEqual({
+      static1: 'static1 - initialValue',
+      static2: 'static2 - initialValue',
+      ['dynamic/reducer']: 'dynamic - initialValue'
+    })
+
+    expect(target).not.toHaveBeenCalled()
   })
 
   test('should dispatch actions', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to redux-dynostore!

Before making a PR please make sure to read our contributing guidelines
https://github.com/ioof-holdings/redux-dynostore/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                       | A
| ----------------------- | ---
| Fixed Issues?           | Fixes #2
| Documentation only PR   | <!--(Can use an emoji 👍) -->
| Patch: Bug Fix?         | <!--(Can use an emoji 👍) -->
| Minor: New Feature?     | 👍
| Major: Breaking Change? | <!--(Can use an emoji 👍) -->
| Tests Added + Pass?     | Yes

<!-- Describe your changes below in as much detail as possible -->

Added 3 new utility functions to the core package:
1. `escapeIdentifier` - escapes `.` and `/` chars in the given string so that they don't trigger nesting logic
2. `escapeIdentifiers` - calls `escapeIdentifiers` on all the keys, and nested keys recursively, of the given object
~3. `unescapeIdentifier` - undoes the escaping of `escapeIdentifiers`

Questions:
~1. Should `unescapeIdentifier` actually be exported?  It's used internally, but not sure if anyone else would actually use it~
2. Should there also be an `unescapeIdentifiers` function? It wasn't needed to implement the escaping logic, but it wouldn't be difficult to add
~3. Should `dynamic` automatically escape the given identifiers?  I have a feeling it's not possible to actually use a component that has a `.` or `/` in the identifier unless it is escaped~