### PR TITLE
Added the ability to remove sagas/reducers

### DIFF
--- a/packages/redux-dynostore-core/src/deletableReducer.js
+++ b/packages/redux-dynostore-core/src/deletableReducer.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const DELETE_TYPE = 'DYNOSTORE/DELETE_REDUCER'
+
+const deletableReducer = (reducer) => (state, action) => {
+  switch (action.type) {
+    case DELETE_TYPE:
+      return null
+    default:
+      return reducer(state, action)
+  }
+}
+
+export default deletableReducer

--- a/packages/redux-dynostore-core/src/filteredReducer.js
+++ b/packages/redux-dynostore-core/src/filteredReducer.js
@@ -18,7 +18,9 @@ const filteredReducer = reducer => {
 
     if (knownKeys.length && state !== undefined) {
       filteredState = knownKeys.reduce((current, key) => {
-        current[key] = state[key]
+        if (state[key] !== null) {
+          current[key] = state[key]
+        }
         return current
       }, {})
     }

--- a/packages/redux-dynostore-core/src/index.js
+++ b/packages/redux-dynostore-core/src/index.js
@@ -13,3 +13,4 @@ export { default as attachReducer } from './attachReducer'
 export { default as dispatchAction } from './dispatchAction'
 
 export { default as createDynamicTarget } from './createDynamicTarget'
+export { default as deletableReducer, DELETE_TYPE } from './deletableReducer'

--- a/packages/redux-dynostore-core/test/deletableReducer.test.js
+++ b/packages/redux-dynostore-core/test/deletableReducer.test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { createStore } from 'redux'
+import { default as deletableReducer, DELETE_TYPE } from 'src/deletableReducer'
+
+describe('deletableReducer Tests', () => {
+
+  test('should forward the dispatched action to the intial reducer and return the expected state', () => {
+      const intialState = { foo: "bar" }
+      const reducer = deletableReducer((state = intialState) => state)
+      const store = createStore(reducer)
+
+      store.dispatch({ type: "FOO" })
+
+      expect(store.getState()).toEqual(intialState)
+  })
+
+  test('should intercept the action and return a null state for this reducer', () => {
+      const intialState = { foo: "bar" }
+      const reducer = deletableReducer((state = intialState) => state)
+      const store = createStore(reducer)
+
+      store.dispatch({ type: DELETE_TYPE })
+
+      expect(store.getState()).toEqual(null)
+  })
+})

--- a/packages/redux-dynostore-core/test/filteredReducer.test.js
+++ b/packages/redux-dynostore-core/test/filteredReducer.test.js
@@ -15,6 +15,7 @@ describe('filteredReducer Tests', () => {
     const plainObject = (state = { test: "value" }) => state
     const array = (state = [ "value" ]) => state
     const changingState = (state = {}, action) => action.type == 'ADD_STATE' ? { ...state, test: "value" } : state
+    const replacingReducer = (state = {test: null}) => state
 
     const testCases = [
         {
@@ -60,6 +61,15 @@ describe('filteredReducer Tests', () => {
             expectedState1: {},
             expectedState2: { test: "value" },
             expectedState3: { test: "other" },
+            expectedState4: { test: "value" }
+        },
+        {
+            name: "replacing reducer",
+            reducer: () => replacingReducer,
+            initialState: { test: "value" },
+            expectedState1: { test: null },
+            expectedState2: { test: null },
+            expectedState3: { test: "value" },
             expectedState4: { test: "value" }
         }
     ]

--- a/packages/redux-dynostore-redux-saga/src/dynamicSagas.js
+++ b/packages/redux-dynostore-redux-saga/src/dynamicSagas.js
@@ -18,11 +18,19 @@ const dynamicSagasEnhancer = sagaMiddleware => createHandlers => (store, ...para
       .forEach(key => (dynamicSagas[key] = sagaMiddleware.run(flattenedSagas[key])))
   }
 
+  const detachSaga = identifier => {
+    if (dynamicSagas[identifier]) {
+      dynamicSagas[identifier].cancel()
+      delete dynamicSagas[identifier]
+    }
+  }
+
   const handlers = createHandlers(store, ...params)
 
   return {
     ...handlers,
-    runSagas
+    runSagas,
+    detachSaga
   }
 }
 

--- a/packages/redux-dynostore-redux-subspace/src/attachReducer.js
+++ b/packages/redux-dynostore-redux-subspace/src/attachReducer.js
@@ -7,10 +7,10 @@
  */
 
 import { namespaced } from 'redux-subspace'
-import { attachReducer } from '@redux-dynostore/core'
+import { attachReducer, deletableReducer } from '@redux-dynostore/core'
 
 const attachNamespacedReducerEnhancer = reducer => identifier => {
-  const namespacedReducer = namespaced(identifier)(reducer)
+  const namespacedReducer = namespaced(identifier)(deletableReducer(reducer))
 
   return store => {
     const storeNamespace = store.namespace


### PR DESCRIPTION
<!--
Thanks for contributing to redux-dynostore!

Before making a PR please make sure to read our contributing guidelines
https://github.com/ioof-holdings/redux-dynostore/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                       | A
| ----------------------- | ---
| Fixed Issues?           | Fixes #14  <!-- remove the (`) quotes to link the issues -->
| Documentation only PR   | <!--(Can use an emoji 👍) -->
| Patch: Bug Fix?         | <!--(Can use an emoji 👍) -->
| Minor: New Feature?     | 👍 <!--(Can use an emoji 👍) -->
| Major: Breaking Change? | <!--(Can use an emoji 👍) -->
| Tests Added + Pass?     | Yes

<!-- Describe your changes below in as much detail as possible -->
I have added the ability to call store.detachReducer(reducerKey) and store.detachSaga(sagaKey) to remove watchers we no longer want.

I have ensured that replacement reducers / sagas with can be re-added after they are removed.

**Note:**
Honestly I struggled a bit understanding how this library works! I have not touched redux middleware / enhancers previously, so this has been a learning experience. As such please don't be shy providing feedback as I suspect changes could be improved. :)

Also I'm not sure if I have placed the all my changes in the right modules. In particular the deletableReducer exists within /core because that made sense to me, however it is actually being used to extend the reducer in /redux-subspace to ensure it gets the namespacing applied.

Finally I just wanted to open this PR to get feedback and make sure I'm on the right path. If all's well or I have some additional feedback to action I will follow the 'add yourself as a contributor' guide.

Cheers!

<!-- Don't forget to [add yourself as a contributor](https://github.com/ioof-holdings/redux-dynostore/blob/master/CONTRIBUTING.md#add-yourself-as-a-contributor) if you're not already -->
