### PR TITLE
Update Immutable.js example with combineReducers

### DIFF
--- a/examples/immutablejs/src/store.js
+++ b/examples/immutablejs/src/store.js
@@ -1,22 +1,25 @@
 import { createStore, compose } from 'redux'
 import { applyMiddleware } from 'redux-subspace'
 import thunk from 'redux-thunk'
-import dynostore, { dynamicReducers } from '@redux-dynostore/core'
+import dynostore, { combineReducers, dynamicReducers } from '@redux-dynostore/core'
 import { Map } from 'immutable'
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 
 export const immutableJsStateHandler = {
   createEmpty: () => Map(),
-  getKeys: state => state.keys(),
+  getKeys: state => state.keySeq(),
   getValue: (state, key) => state.get(key),
   setValue: (state, key, value) => state.set(key, value),
   canMerge: state => Map.isMap(state),
   merge: (oldState, newState) => (oldState ? oldState.merge(newState) : newState)
 }
 
+const reducer1 = (state = Map()) => state,
+  reducer2 =  (state = Map()) => state;
+
 const store = createStore(
-  (state = Map()) => state,
+  combineReducers({ reducer1, reducer2 }, { stateHandler: immutableJsStateHandler }),
   composeEnhancers(applyMiddleware(thunk), dynostore(dynamicReducers(), { stateHandler: immutableJsStateHandler }))
 )
 


### PR DESCRIPTION
| Q                       | A
| ----------------------- | ---
| Fixed Issues?           | Fixes #218 
| Documentation only PR   | Sort of
| Patch: Bug Fix?         | Yes
| Minor: New Feature?     | No
| Major: Breaking Change? | No
| Tests Added + Pass?     | No

`state.keys()` returns an ES6 iterator, which doesn't have `forEach()`. The redux-dynostore `combineReducers()` must be used, and must have `stateHandler` passed; using redux-immutable's `combineReducers()` won't work.
