### PR TITLE
Fix/cross component update warning

### DIFF
--- a/examples/immutablejs/package.json
+++ b/examples/immutablejs/package.json
@@ -1,15 +1,15 @@
 {
   "name": "immutable-counter",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "3.4.3"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
     "immutable": "4.0.0-rc.12",
     "prop-types": "15.7.2",
     "react": "16.13.1",

--- a/examples/microfrontends/lerna.json
+++ b/examples/microfrontends/lerna.json
@@ -1,5 +1,6 @@
 {
   "lerna": "3.5.1",
   "packages": ["packages/*"],
+  "hoist": true,
   "version": "1.1.0"
 }

--- a/examples/microfrontends/package.json
+++ b/examples/microfrontends/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfrontends-example",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "@reach/router": "1.3.4",
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-loadable": "5.5.0",

--- a/examples/microfrontends/package.json
+++ b/examples/microfrontends/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.0",
   "private": true,
   "scripts": {
-    "bootstrap": "lerna bootstrap --hoist",
+    "bootstrap": "lerna bootstrap",
     "postinstall": "npm run bootstrap",
     "prebuild": "npm run externals:build",
     "prestart": "npm run externals:build",

--- a/examples/microfrontends/packages/common-packages/package.json
+++ b/examples/microfrontends/packages/common-packages/package.json
@@ -1,16 +1,16 @@
 {
   "name": "common-packages",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
     "@reach/router": "1.3.4",
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-redux": "7.2.1",

--- a/examples/microfrontends/packages/counter/package.json
+++ b/examples/microfrontends/packages/counter/package.json
@@ -1,15 +1,15 @@
 {
   "name": "counter-microfrontend",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
     "react": "16.13.1",
     "react-redux": "7.2.1",
     "redux": "4.0.5"

--- a/examples/microfrontends/packages/home/package.json
+++ b/examples/microfrontends/packages/home/package.json
@@ -1,6 +1,6 @@
 {
   "name": "home-microfrontend",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "scripts": {
     "build": "webpack"

--- a/examples/microfrontends/packages/todos/package.json
+++ b/examples/microfrontends/packages/todos/package.json
@@ -1,15 +1,15 @@
 {
   "name": "todos-microfrontend",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-redux": "7.2.1",

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "real-world",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "3.4.3",
@@ -10,10 +10,10 @@
     "redux-logger": "3.0.6"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
     "connected-react-router": "6.8.0",
     "humps": "2.0.1",
     "lodash": "4.17.20",

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -21,7 +21,6 @@
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "react-loadable": "5.5.0",
     "react-redux": "7.2.1",
     "react-redux-subspace": "6.1.0",
     "react-router": "5.2.0",

--- a/examples/real-world/src/app/components/Explore.js
+++ b/examples/real-world/src/app/components/Explore.js
@@ -10,9 +10,9 @@ export default class Explore extends Component {
     githubRepo: PropTypes.string.isRequired
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.value !== this.props.value) {
-      this.setInputValue(nextProps.value)
+  componentDidUpdate(prevProps) {
+    if (this.props.value !== prevProps.value) {
+      this.setInputValue(this.props.value)
     }
   }
 

--- a/examples/real-world/src/repoPage/RepoPage.js
+++ b/examples/real-world/src/repoPage/RepoPage.js
@@ -8,10 +8,9 @@ import User from '../common/components/User'
 import List from '../common/components/List'
 import { loadRepo, loadStargazers } from './actions'
 
-const loadData = props => {
-  const { fullName } = props
-  props.loadRepo(fullName, ['description'])
-  props.loadStargazers(fullName)
+const loadData = ({ fullName, loadRepo, loadStargazers }) => {
+  loadRepo(fullName, ['description'])
+  loadStargazers(fullName)
 }
 
 class RepoPage extends Component {
@@ -26,13 +25,13 @@ class RepoPage extends Component {
     loadStargazers: PropTypes.func.isRequired
   }
 
-  componentWillMount() {
+  componentDidMount() {
     loadData(this.props)
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.fullName !== this.props.fullName) {
-      loadData(nextProps)
+  componentDidUpdate(prevProps) {
+    if (this.props.fullName !== prevProps.fullName) {
+      loadData(this.props)
     }
   }
 

--- a/examples/real-world/src/root/Routes.js
+++ b/examples/real-world/src/root/Routes.js
@@ -1,40 +1,27 @@
 /* eslint-disable react/display-name */
-import React from 'react'
+import React, { Suspense } from 'react'
 import { Route, Switch } from 'react-router'
-import Loadable from 'react-loadable'
+import App from '../app'
+
+const RepoPage = React.lazy(() => import('../repoPage'))
+const UserPage = React.lazy(() => import('../userPage'))
 
 const Loading = () => <p>Loading...</p>
 
-const App = Loadable({
-  loader: () => import('../app'),
-  loading: Loading,
-  render: ({ default: Component }, props) => <Component {...props} />
-})
-
-const RepoPage = Loadable({
-  loader: () => import('../repoPage'),
-  loading: Loading,
-  render: ({ default: Component }, props) => <Component {...props} />
-})
-
-const UserPage = Loadable({
-  loader: () => import('../userPage'),
-  loading: Loading,
-  render: ({ default: Component }, props) => <Component {...props} />
-})
-
 const Routes = () => (
-  <Route
-    path="/"
-    render={props => (
-      <App {...props}>
-        <Switch>
-          <Route path="/:login/:name" component={RepoPage} />
-          <Route path="/:login" component={UserPage} />
-        </Switch>
-      </App>
-    )}
-  />
+  <Suspense fallback={Loading}>
+    <Route
+      path="/"
+      render={props => (
+        <App {...props}>
+          <Switch>
+            <Route path="/:login/:name" component={RepoPage} />
+            <Route path="/:login" component={UserPage} />
+          </Switch>
+        </App>
+      )}
+    />
+  </Suspense>
 )
 
 export default Routes

--- a/examples/real-world/src/userPage/UserPage.js
+++ b/examples/real-world/src/userPage/UserPage.js
@@ -25,13 +25,13 @@ class UserPage extends Component {
     loadStarred: PropTypes.func.isRequired
   }
 
-  componentWillMount() {
+  componentDidMount() {
     loadData(this.props)
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.login !== this.props.login) {
-      loadData(nextProps)
+  componentDidUpdate(prevProps) {
+    if (this.props.login !== prevProps.login) {
+      loadData(this.props)
     }
   }
 

--- a/examples/redux-saga/cancellable-counter/package.json
+++ b/examples/redux-saga/cancellable-counter/package.json
@@ -1,17 +1,17 @@
 {
   "name": "cancellable-counter",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "3.4.3"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-saga": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace-saga": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-saga": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace-saga": "^3.1.1-alpha.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/examples/redux-saga/dynamic-counters/package.json
+++ b/examples/redux-saga/dynamic-counters/package.json
@@ -1,17 +1,17 @@
 {
   "name": "dynamic-list-counters",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "3.4.3"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-saga": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace-saga": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-saga": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace-saga": "^3.1.1-alpha.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -1,15 +1,15 @@
 {
   "name": "todos",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "3.4.3"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.1.1-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.1.1-alpha.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,6 @@
       "ignore": "microfrontends-example"
     }
   },
+  "hoist": true,
   "version": "3.1.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     }
   },
   "hoist": true,
-  "version": "3.1.0"
+  "version": "3.1.1-alpha.0"
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "rimraf": "3.0.2"
   },
   "scripts": {
-    "bootstrap": "lerna bootstrap --hoist",
+    "bootstrap": "lerna bootstrap",
     "postinstall": "npm run bootstrap",
     "build": "lerna run --parallel build",
     "test": "lerna run test && istanbul report --root packages --reporter text-summary",

--- a/packages/performance-tests/package.json
+++ b/packages/performance-tests/package.json
@@ -1,12 +1,12 @@
 {
   "name": "performance-tests",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "private": true,
   "description": "performance tests for redux-dynostore",
   "author": "Michael Peyper",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
     "redux": "4.0.5"
   },
   "devDependencies": {

--- a/packages/redux-dynostore-core/package.json
+++ b/packages/redux-dynostore-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/core",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "description": "Enhance Redux stores to allow additional functionality to be dynamically added at runtime",
   "author": "Michael Peyper",
   "contributors": [

--- a/packages/redux-dynostore-react-redux-subspace/package.json
+++ b/packages/redux-dynostore-react-redux-subspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/react-redux-subspace",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "description": "react-redux-subspace extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -36,8 +36,8 @@
     "@babel/plugin-transform-modules-commonjs": "7.10.4",
     "@babel/preset-env": "7.11.0",
     "@babel/preset-react": "7.10.4",
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
+    "@redux-dynostore/react-redux": "^3.1.1-alpha.0",
     "@testing-library/react": "10.4.8",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",

--- a/packages/redux-dynostore-react-redux/package.json
+++ b/packages/redux-dynostore-react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/react-redux",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "description": "Call dynostore enhancers when a React component is mounted",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
     "hoist-non-react-statics": "^3.3.0",
     "recompose": "^0.30.0"
   },

--- a/packages/redux-dynostore-react-redux/src/dynamic.js
+++ b/packages/redux-dynostore-react-redux/src/dynamic.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useContext, useMemo } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { ReactReduxContext } from 'react-redux'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import wrapDisplayName from 'recompose/wrapDisplayName'
@@ -25,8 +25,11 @@ const createDynamic = (identifier, enhancers, options) => {
   return Component => {
     const Dynamic = React.forwardRef((props, ref) => {
       const { store } = useContext(context)
-      const EnhancedComponent = useMemo(() => dynamicEnhancer(store)(Component), [store])
-      return <EnhancedComponent identifier={identifier} {...props} ref={ref} />
+      const [EnhancedComponent, setEnhancedComponent] = useState(null)
+      useEffect(() => {
+        setEnhancedComponent(() => dynamicEnhancer(store)(Component))
+      }, [store])
+      return EnhancedComponent && <EnhancedComponent identifier={identifier} {...props} ref={ref} />
     })
 
     hoistNonReactStatics(Dynamic, Component)

--- a/packages/redux-dynostore-redux-saga/package.json
+++ b/packages/redux-dynostore-redux-saga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-saga",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "description": "Dynamically add Redux sagas at runtime",
   "author": "Michael Peyper",
   "contributors": [
@@ -34,7 +34,7 @@
     "@babel/plugin-transform-runtime": "7.11.0",
     "@babel/preset-env": "7.11.0",
     "@babel/runtime": "7.11.2",
-    "@redux-dynostore/core": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.3.0",

--- a/packages/redux-dynostore-redux-subspace-saga/package.json
+++ b/packages/redux-dynostore-redux-subspace-saga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-subspace-saga",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "description": "redux-subspace-saga extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/redux-saga": "^3.1.0",
+    "@redux-dynostore/redux-saga": "^3.1.1-alpha.0",
     "redux-subspace": "^6.1.0",
     "redux-subspace-saga": "^6.1.0"
   },
@@ -38,7 +38,7 @@
     "@babel/plugin-transform-runtime": "7.11.0",
     "@babel/preset-env": "7.11.0",
     "@babel/runtime": "7.11.2",
-    "@redux-dynostore/core": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.3.0",

--- a/packages/redux-dynostore-redux-subspace/package.json
+++ b/packages/redux-dynostore-redux-subspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-subspace",
-  "version": "3.1.0",
+  "version": "3.1.1-alpha.0",
   "description": "redux-subspace extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
+    "@redux-dynostore/core": "^3.1.1-alpha.0",
     "redux-subspace": "^6.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Thanks for contributing to redux-dynostore!

Before making a PR please make sure to read our contributing guidelines
https://github.com/ioof-holdings/redux-dynostore/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                       | A
| ----------------------- | ---
| Fixed Issues?           | Fixes #234
| Documentation only PR   | <!--(Can use an emoji 👍) -->
| Patch: Bug Fix?         | <!--(Can use an emoji 👍) -->
| Minor: New Feature?     | <!--(Can use an emoji 👍) -->
| Major: Breaking Change? | <!--(Can use an emoji 👍) -->
| Tests Added + Pass?     | Yes

<!-- Describe your changes below in as much detail as possible -->

Moved the store and component enhancement of the "dynamic target" chain into `useEffect` of `dynamic`, preventing the `attachReducer` call (and any other enhancers that trigger a store update`) from updating the store in the main render path.

This change has an assumption that is is ok to render `null` for a single render until the store has been updated.  Once the effect has triggered, the enhanced component will be created and set into state where it can be safely rendered in the subsequent renders.  I think this is ok, but it is a change from the existing functionality, although it may improve a previously raised issues around concurrent mode and render tearing (where some of the rendering uses a particular instance of state and the another part uses a different instance of state, potentially creating inconsistent output).

I'm not sure if this should be a breaking change, in case anyone is relying on this behaviour, a minor change, because we may have introduced a new feature to prevent tearing, or a minor change, because we're fixing a warning about a potential bugs.

I'm leaning towards a major version, but I'm also open to being convinced it only a minor or patch version.

<!-- Don't forget to [add yourself as a contributor](https://github.com/ioof-holdings/redux-dynostore/blob/master/CONTRIBUTING.md#add-yourself-as-a-contributor) if you're not already -->
