### PR TITLE
Synchronously enhance component when running on the server

### DIFF
--- a/examples/immutablejs/package.json
+++ b/examples/immutablejs/package.json
@@ -1,15 +1,15 @@
 {
   "name": "immutable-counter",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
-    "@redux-dynostore/react-redux": "^3.1.1",
-    "@redux-dynostore/react-redux-subspace": "^3.1.1",
-    "@redux-dynostore/redux-subspace": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
     "immutable": "4.0.0-rc.12",
     "prop-types": "15.7.2",
     "react": "16.14.0",

--- a/examples/immutablejs/package.json
+++ b/examples/immutablejs/package.json
@@ -1,15 +1,15 @@
 {
   "name": "immutable-counter",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
     "immutable": "4.0.0-rc.12",
     "prop-types": "15.7.2",
     "react": "16.14.0",

--- a/examples/microfrontends/package.json
+++ b/examples/microfrontends/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfrontends-example",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "@reach/router": "1.3.4",
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-loadable": "5.5.0",

--- a/examples/microfrontends/package.json
+++ b/examples/microfrontends/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfrontends-example",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "@reach/router": "1.3.4",
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-loadable": "5.5.0",

--- a/examples/microfrontends/packages/common-packages/package.json
+++ b/examples/microfrontends/packages/common-packages/package.json
@@ -1,16 +1,16 @@
 {
   "name": "common-packages",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
     "@reach/router": "1.3.4",
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-redux": "7.2.2",

--- a/examples/microfrontends/packages/common-packages/package.json
+++ b/examples/microfrontends/packages/common-packages/package.json
@@ -1,16 +1,16 @@
 {
   "name": "common-packages",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
     "@reach/router": "1.3.4",
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-redux": "7.2.2",

--- a/examples/microfrontends/packages/counter/package.json
+++ b/examples/microfrontends/packages/counter/package.json
@@ -1,15 +1,15 @@
 {
   "name": "counter-microfrontend",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
     "react": "16.14.0",
     "react-redux": "7.2.2",
     "redux": "4.0.5"

--- a/examples/microfrontends/packages/counter/package.json
+++ b/examples/microfrontends/packages/counter/package.json
@@ -1,15 +1,15 @@
 {
   "name": "counter-microfrontend",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
-    "@redux-dynostore/react-redux-subspace": "^3.1.0",
-    "@redux-dynostore/redux-subspace": "^3.1.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
     "react": "16.14.0",
     "react-redux": "7.2.2",
     "redux": "4.0.5"

--- a/examples/microfrontends/packages/home/package.json
+++ b/examples/microfrontends/packages/home/package.json
@@ -1,6 +1,6 @@
 {
   "name": "home-microfrontend",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "scripts": {
     "build": "webpack"

--- a/examples/microfrontends/packages/home/package.json
+++ b/examples/microfrontends/packages/home/package.json
@@ -1,6 +1,6 @@
 {
   "name": "home-microfrontend",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "scripts": {
     "build": "webpack"

--- a/examples/microfrontends/packages/todos/package.json
+++ b/examples/microfrontends/packages/todos/package.json
@@ -1,15 +1,15 @@
 {
   "name": "todos-microfrontend",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
-    "@redux-dynostore/react-redux": "^3.1.1",
-    "@redux-dynostore/react-redux-subspace": "^3.1.1",
-    "@redux-dynostore/redux-subspace": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-redux": "7.2.2",

--- a/examples/microfrontends/packages/todos/package.json
+++ b/examples/microfrontends/packages/todos/package.json
@@ -1,15 +1,15 @@
 {
   "name": "todos-microfrontend",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "scripts": {
     "build": "webpack"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-redux": "7.2.2",

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "real-world",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1",
@@ -10,10 +10,10 @@
     "redux-logger": "3.0.6"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
-    "@redux-dynostore/react-redux": "^3.1.1",
-    "@redux-dynostore/react-redux-subspace": "^3.1.1",
-    "@redux-dynostore/redux-subspace": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
     "connected-react-router": "6.8.0",
     "humps": "2.0.1",
     "lodash": "4.17.20",

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "real-world",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1",
@@ -10,10 +10,10 @@
     "redux-logger": "3.0.6"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
     "connected-react-router": "6.8.0",
     "humps": "2.0.1",
     "lodash": "4.17.20",

--- a/examples/redux-saga/cancellable-counter/package.json
+++ b/examples/redux-saga/cancellable-counter/package.json
@@ -1,17 +1,17 @@
 {
   "name": "cancellable-counter",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
-    "@redux-dynostore/react-redux": "^3.1.1",
-    "@redux-dynostore/react-redux-subspace": "^3.1.1",
-    "@redux-dynostore/redux-saga": "^3.1.1",
-    "@redux-dynostore/redux-subspace": "^3.1.1",
-    "@redux-dynostore/redux-subspace-saga": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-saga": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace-saga": "^3.2.0-alpha.0",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/examples/redux-saga/cancellable-counter/package.json
+++ b/examples/redux-saga/cancellable-counter/package.json
@@ -1,17 +1,17 @@
 {
   "name": "cancellable-counter",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-saga": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace-saga": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-saga": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace-saga": "^3.2.0-alpha.1",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/examples/redux-saga/dynamic-counters/package.json
+++ b/examples/redux-saga/dynamic-counters/package.json
@@ -1,17 +1,17 @@
 {
   "name": "dynamic-list-counters",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
-    "@redux-dynostore/react-redux": "^3.1.1",
-    "@redux-dynostore/react-redux-subspace": "^3.1.1",
-    "@redux-dynostore/redux-saga": "^3.1.1",
-    "@redux-dynostore/redux-subspace": "^3.1.1",
-    "@redux-dynostore/redux-subspace-saga": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-saga": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace-saga": "^3.2.0-alpha.0",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/examples/redux-saga/dynamic-counters/package.json
+++ b/examples/redux-saga/dynamic-counters/package.json
@@ -1,17 +1,17 @@
 {
   "name": "dynamic-list-counters",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-saga": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace-saga": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-saga": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace-saga": "^3.2.0-alpha.1",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -1,15 +1,15 @@
 {
   "name": "todos",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
-    "@redux-dynostore/react-redux": "^3.1.1",
-    "@redux-dynostore/react-redux-subspace": "^3.1.1",
-    "@redux-dynostore/redux-subspace": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -1,15 +1,15 @@
 {
   "name": "todos",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "devDependencies": {
     "react-scripts": "4.0.1"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.0",
-    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux-subspace": "^3.2.0-alpha.1",
+    "@redux-dynostore/redux-subspace": "^3.2.0-alpha.1",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     }
   },
   "hoist": true,
-  "version": "3.2.0-alpha.0"
+  "version": "3.2.0-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     }
   },
   "hoist": true,
-  "version": "3.1.1"
+  "version": "3.2.0-alpha.0"
 }

--- a/packages/performance-tests/package.json
+++ b/packages/performance-tests/package.json
@@ -1,12 +1,12 @@
 {
   "name": "performance-tests",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "private": true,
   "description": "performance tests for redux-dynostore",
   "author": "Michael Peyper",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
     "redux": "4.0.5"
   },
   "devDependencies": {

--- a/packages/performance-tests/package.json
+++ b/packages/performance-tests/package.json
@@ -1,12 +1,12 @@
 {
   "name": "performance-tests",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "private": true,
   "description": "performance tests for redux-dynostore",
   "author": "Michael Peyper",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
     "redux": "4.0.5"
   },
   "devDependencies": {

--- a/packages/redux-dynostore-core/package.json
+++ b/packages/redux-dynostore-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/core",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "description": "Enhance Redux stores to allow additional functionality to be dynamically added at runtime",
   "author": "Michael Peyper",
   "contributors": [

--- a/packages/redux-dynostore-core/package.json
+++ b/packages/redux-dynostore-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/core",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "Enhance Redux stores to allow additional functionality to be dynamically added at runtime",
   "author": "Michael Peyper",
   "contributors": [

--- a/packages/redux-dynostore-react-redux-subspace/package.json
+++ b/packages/redux-dynostore-react-redux-subspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/react-redux-subspace",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "description": "react-redux-subspace extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -36,8 +36,8 @@
     "@babel/plugin-transform-modules-commonjs": "7.12.1",
     "@babel/preset-env": "7.12.11",
     "@babel/preset-react": "7.12.10",
-    "@redux-dynostore/core": "^3.1.0",
-    "@redux-dynostore/react-redux": "^3.1.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
     "@testing-library/react": "11.2.3",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",

--- a/packages/redux-dynostore-react-redux-subspace/package.json
+++ b/packages/redux-dynostore-react-redux-subspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/react-redux-subspace",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "react-redux-subspace extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -36,8 +36,8 @@
     "@babel/plugin-transform-modules-commonjs": "7.12.1",
     "@babel/preset-env": "7.12.11",
     "@babel/preset-react": "7.12.10",
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
-    "@redux-dynostore/react-redux": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
+    "@redux-dynostore/react-redux": "^3.2.0-alpha.1",
     "@testing-library/react": "11.2.3",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",

--- a/packages/redux-dynostore-react-redux/README.md
+++ b/packages/redux-dynostore-react-redux/README.md
@@ -44,6 +44,32 @@ export default dynamic('identifier', somethingDynamic(), { context: CustomReactR
 
 This option overrides the `context` used for accessing the store in the React context.  If you are overriding this value, you should also be overriding the context passed to any `Provider` and/or `connect` components as well.  Please refer to the [Redux documentation](https://react-redux.js.org/using-react-redux/accessing-store#providing-custom-context) for more details on this use case.
 
+### `DynamicProvider`
+
+`dynamic` components will not render when server-side rendering (SSR) your app unless you add a `DynamicProvider` somewhere near the root of of your component tree (anywhere above the the first `dynamic` component).
+This will allow the component to call their enhancers synchronously in the first render pass.  You must also ensure that the `DynamicProvider` is also rendered when hydrating that app on the client.
+
+```js
+import ReactDom from 'react'
+import { Provider } from 'react-redux'
+import dynamic, { DynamicProvider } from '@redux-dynostore/react-redux'
+
+import store from './store'
+import MyDynamicComponent from './MyDynamicComponent
+
+ReactDom.render((
+  <Provider store={store}>
+    <DynamicProvider>
+      <MyDynamicComponent />
+    </DynamicProvider>
+  </Provider>
+), document.getElementById('root'))
+```
+
+While not required for client-side rendering (CSR), `DynamicProvider`, it can also slightly improve performance of the first render pass.  It's use in CSR is generally not advised and not a supported use case, so use it at your own risk.
+
+#### Server-Side Rendering (SSR)
+
 ## Enhancers
 
 Enhancers are used to provide additional wrappers around the passed component when it is mounted. The following enhancers are provided:

--- a/packages/redux-dynostore-react-redux/README.md
+++ b/packages/redux-dynostore-react-redux/README.md
@@ -99,11 +99,11 @@ Enhancers are used to provide additional wrappers around the passed component wh
 4. [Subspaced](/packages/redux-dynostore-react-redux-subspace) - mounts the component is in a subspace for the components identifier
    1. [Namespaced Reducers](/packages/redux-dynostore-redux-subspace) - dynamically attach reducers that are namespaced with the component's identifier
    2. [Subspaced Sagas](/packages/redux-dynostore-redux-subspace-saga) - dynamically run sagas that are subspaced for the component's identifier
-   3. [Dispatch Namepsaced Action](/packages/redux-dynostore-redux-subspace) - dispatch actions when the component is mounted that are namespaced with the component's identifier
+   3. [Dispatch Namespaced Action](/packages/redux-dynostore-redux-subspace) - dispatch actions when the component is mounted that are namespaced with the component's identifier
 
 ### Custom Enhancers
 
-Enahncers can be created for many use cases by implementing the following interface:
+Enhancers can be created for many use cases by implementing the following interface:
 
 ```javascript
 const enhancer = identifier => store => Component => EnhancedComponent

--- a/packages/redux-dynostore-react-redux/README.md
+++ b/packages/redux-dynostore-react-redux/README.md
@@ -66,7 +66,28 @@ ReactDom.render((
 ), document.getElementById('root'))
 ```
 
-While not required for client-side rendering (CSR), `DynamicProvider`, it can also slightly improve performance of the first render pass.  It's use in CSR is generally not advised and not a supported use case, so use it at your own risk.
+You can also nest multiple `DynamicProvider` components within each other.
+
+```js
+ReactDom.render((
+  <Provider store={store}>
+    <DynamicProvider>
+      <ParentDynamicComponent>
+        <DynamicProvider>
+          <ChildDynamicComponent />
+        </DynamicProvider>
+      </ParentDynamicComponent>
+    </DynamicProvider>
+  </Provider>
+), document.getElementById('root'))
+```
+
+One example of when you might do this is when composing multiple sub-apps together into a parent-app and each app could have their own `DynamicProvider` instance.
+However, it is important to that the root `DynamicProvider` does not get unmounted and remounted as this will another synchronous render pass to occur after the first render, which will produce warnings from React about cross component
+updates.
+
+While not required for client-side rendering (CSR), `DynamicProvider`, it can also slightly improve performance of the first render pass, however, due to limited testing, there might be unforeseen impacts of using this in an a CSR
+context, so use it at your own risk.
 
 ## Enhancers
 

--- a/packages/redux-dynostore-react-redux/README.md
+++ b/packages/redux-dynostore-react-redux/README.md
@@ -68,8 +68,6 @@ ReactDom.render((
 
 While not required for client-side rendering (CSR), `DynamicProvider`, it can also slightly improve performance of the first render pass.  It's use in CSR is generally not advised and not a supported use case, so use it at your own risk.
 
-#### Server-Side Rendering (SSR)
-
 ## Enhancers
 
 Enhancers are used to provide additional wrappers around the passed component when it is mounted. The following enhancers are provided:

--- a/packages/redux-dynostore-react-redux/package.json
+++ b/packages/redux-dynostore-react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/react-redux",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "description": "Call dynostore enhancers when a React component is mounted",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
     "hoist-non-react-statics": "^3.3.0",
     "recompose": "^0.30.0"
   },

--- a/packages/redux-dynostore-react-redux/package.json
+++ b/packages/redux-dynostore-react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/react-redux",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "Call dynostore enhancers when a React component is mounted",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
     "hoist-non-react-statics": "^3.3.0",
     "recompose": "^0.30.0"
   },

--- a/packages/redux-dynostore-react-redux/src/dynamic.js
+++ b/packages/redux-dynostore-react-redux/src/dynamic.js
@@ -18,15 +18,15 @@ const splitOptions = args => {
   return isObject(lastItem) ? [args.slice(0, -1), lastItem] : [args, {}]
 }
 
-const DynamicContext = React.createContext(false)
+const DynamicContext = React.createContext(null)
 
 // eslint-disable-next-line react/prop-types
 export const DynamicProvider = ({ children }) => {
-  const [firstRender, setFirstRender] = useState(true);
-
+  const inheritedFirstRender = useContext(DynamicContext)
+  const [firstRender, setFirstRender] = useState(inheritedFirstRender === null)
   useEffect(() => {
-    setFirstRender(false);
-  }, []);
+    setFirstRender(false)
+  }, [])
 
   return <DynamicContext.Provider value={firstRender}>{children}</DynamicContext.Provider>
 }

--- a/packages/redux-dynostore-react-redux/src/dynamic.js
+++ b/packages/redux-dynostore-react-redux/src/dynamic.js
@@ -40,7 +40,7 @@ const createDynamic = (identifier, enhancers, options) => {
       const [lastStore, setLastStore] = useState(store)
       const firstRender = useContext(DynamicContext)
 
-      const [EnhancedComponent, setEnhancedComponent] = useState(() => firstRender ? dynamicEnhancer(store)(Component) : null);
+      const [EnhancedComponent, setEnhancedComponent] = useState(() => firstRender && dynamicEnhancer(store)(Component));
 
       useEffect(() => {
         if (!EnhancedComponent || store !== lastStore) {

--- a/packages/redux-dynostore-react-redux/src/index.js
+++ b/packages/redux-dynostore-react-redux/src/index.js
@@ -6,4 +6,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { default } from './dynamic'
+export { default, DynamicProvider } from './dynamic'

--- a/packages/redux-dynostore-react-redux/test/integration.test.js
+++ b/packages/redux-dynostore-react-redux/test/integration.test.js
@@ -28,7 +28,7 @@ describe('integration tests', () => {
     store = createStore((state = {}) => state, dynostore())
   })
 
-  test('should enhance component with dynamic enhaners', () => {
+  test('should enhance component with dynamic enhancers', () => {
     const mockFn = jest.fn()
     const DynamicComponent = dynamic('testId', testDynamicEnhancer(mockFn))(TestComponent)
     const { getByText } = render(

--- a/packages/redux-dynostore-redux-saga/package.json
+++ b/packages/redux-dynostore-redux-saga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-saga",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "Dynamically add Redux sagas at runtime",
   "author": "Michael Peyper",
   "contributors": [
@@ -34,7 +34,7 @@
     "@babel/plugin-transform-runtime": "7.12.10",
     "@babel/preset-env": "7.12.11",
     "@babel/runtime": "7.12.5",
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",

--- a/packages/redux-dynostore-redux-saga/package.json
+++ b/packages/redux-dynostore-redux-saga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-saga",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "description": "Dynamically add Redux sagas at runtime",
   "author": "Michael Peyper",
   "contributors": [
@@ -34,7 +34,7 @@
     "@babel/plugin-transform-runtime": "7.12.10",
     "@babel/preset-env": "7.12.11",
     "@babel/runtime": "7.12.5",
-    "@redux-dynostore/core": "^3.1.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",

--- a/packages/redux-dynostore-redux-subspace-saga/package.json
+++ b/packages/redux-dynostore-redux-subspace-saga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-subspace-saga",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "description": "redux-subspace-saga extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/redux-saga": "^3.1.1",
+    "@redux-dynostore/redux-saga": "^3.2.0-alpha.0",
     "redux-subspace": "^6.1.0",
     "redux-subspace-saga": "^6.1.0"
   },
@@ -38,7 +38,7 @@
     "@babel/plugin-transform-runtime": "7.12.10",
     "@babel/preset-env": "7.12.11",
     "@babel/runtime": "7.12.5",
-    "@redux-dynostore/core": "^3.1.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",

--- a/packages/redux-dynostore-redux-subspace-saga/package.json
+++ b/packages/redux-dynostore-redux-subspace-saga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-subspace-saga",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "redux-subspace-saga extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/redux-saga": "^3.2.0-alpha.0",
+    "@redux-dynostore/redux-saga": "^3.2.0-alpha.1",
     "redux-subspace": "^6.1.0",
     "redux-subspace-saga": "^6.1.0"
   },
@@ -38,7 +38,7 @@
     "@babel/plugin-transform-runtime": "7.12.10",
     "@babel/preset-env": "7.12.11",
     "@babel/runtime": "7.12.5",
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",

--- a/packages/redux-dynostore-redux-subspace/package.json
+++ b/packages/redux-dynostore-redux-subspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-subspace",
-  "version": "3.1.1",
+  "version": "3.2.0-alpha.0",
   "description": "redux-subspace extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.1.1",
+    "@redux-dynostore/core": "^3.2.0-alpha.0",
     "redux-subspace": "^6.1.0"
   },
   "peerDependencies": {

--- a/packages/redux-dynostore-redux-subspace/package.json
+++ b/packages/redux-dynostore-redux-subspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-dynostore/redux-subspace",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "redux-subspace extensions for redux-dynostore",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-dynostore.git"
   },
   "dependencies": {
-    "@redux-dynostore/core": "^3.2.0-alpha.0",
+    "@redux-dynostore/core": "^3.2.0-alpha.1",
     "redux-subspace": "^6.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Thanks for contributing to redux-dynostore!

Before making a PR please make sure to read our contributing guidelines
https://github.com/ioof-holdings/redux-dynostore/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                       | A
| ----------------------- | ---
| Fixed Issues?           | Fixes #473
| Documentation only PR   | 👍
| Patch: Bug Fix?         | 👍
| Minor: New Feature?     | 
| Major: Breaking Change? | 
| Tests Added + Pass?     | No + Yes

<!-- Describe your changes below in as much detail as possible -->

As per #473, the recent changes to prevent a react warning about cross component updates broke SSR rendering.  This change attempts to identify when the component is rendering one the server (`typeof window === 'undefined'`) and synchronously enhances the component, while still only enhancing as an effect when rendering on the client.

What I don't know (and don't have an SSR environment to test in) is if there is a single render of `null` after hydration on the client.  I don't _think_ it will, but I'm not sure.

I also haven't written a test for this scenario as I'm not sure how remove `window` from the test environments for a since case.  Happy to write it if anyone has any bright ideas on this?

<!-- Don't forget to [add yourself as a contributor](https://github.com/ioof-holdings/redux-dynostore/blob/master/CONTRIBUTING.md#add-yourself-as-a-contributor) if you're not already -->
